### PR TITLE
v4.8.1

### DIFF
--- a/MoneyFromMobs/src/me/chocolf/moneyfrommobs/managers/LevelledMobsManager.java
+++ b/MoneyFromMobs/src/me/chocolf/moneyfrommobs/managers/LevelledMobsManager.java
@@ -1,0 +1,34 @@
+package me.chocolf.moneyfrommobs.managers;
+
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Entity;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Objects;
+
+public class LevelledMobsManager {
+    private final Boolean levelledMobsIsInstalled;
+    private NamespacedKey key;
+
+    public LevelledMobsManager(){
+        Plugin levelledMobsPlugin = Bukkit.getPluginManager().getPlugin("LevelledMobs");
+        levelledMobsIsInstalled = levelledMobsPlugin != null && levelledMobsPlugin.isEnabled();
+
+        if (levelledMobsIsInstalled){
+            key = new NamespacedKey(levelledMobsPlugin, "level");
+        }
+    }
+
+    public boolean hasLevelledMobsInstalled(){
+        return levelledMobsIsInstalled != null && levelledMobsIsInstalled;
+    }
+
+    public int getLevelledMobsMobLevel(Entity entity){
+        if (!hasLevelledMobsInstalled()) return 0;
+
+        Integer mobLevel = entity.getPersistentDataContainer().get(key, PersistentDataType.INTEGER);
+        return Objects.requireNonNullElse(mobLevel, 0);
+    }
+}

--- a/MoneyFromMobs/src/me/chocolf/moneyfrommobs/managers/MultipliersManager.java
+++ b/MoneyFromMobs/src/me/chocolf/moneyfrommobs/managers/MultipliersManager.java
@@ -10,7 +10,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -18,15 +17,13 @@ import io.hotmail.com.jacob_vejvoda.infernal_mobs.infernal_mobs;
 import io.lumine.mythic.bukkit.MythicBukkit;
 import me.chocolf.moneyfrommobs.MoneyFromMobs;
 import me.chocolf.moneyfrommobs.utils.RandomNumberUtils;
-import me.lokka30.levelledmobs.LevelInterface;
-import me.lokka30.levelledmobs.LevelledMobs;
 import org.bukkit.scheduler.BukkitTask;
 
 public class MultipliersManager {
 	
 	private final MoneyFromMobs plugin;
-	private static LevelInterface levelledMobsAPI;
 	private static infernal_mobs infernalMobsAPI;
+	private LevelledMobsManager levelledMobsManager;
 	private static GuildsAPI guildsAPI;
 	private double lootingMultiplier;
 	private double eventMultiplier = 0;
@@ -165,8 +162,9 @@ public class MultipliersManager {
 	private double applyLevelledMobsMultiplier(double amountToAdd, Entity entity) {
 		if (levelledMobsMultiplier == 0)
 			return 0;
-		if ( levelledMobsAPI.isLevelled(( LivingEntity) entity) ) {
-			int level = levelledMobsAPI.getLevelOfMob((LivingEntity) entity);
+
+		int level = levelledMobsManager.getLevelledMobsMobLevel(entity);
+		if (level > 0) {
 			return amountToAdd * levelledMobsMultiplier * (level-1);
 		}
 		return 0;
@@ -262,8 +260,9 @@ public class MultipliersManager {
 	}
 	
 	private void loadLevelledMobsMultiplier(FileConfiguration config) {
-		if (Bukkit.getPluginManager().isPluginEnabled("LevelledMobs")) {
-			levelledMobsAPI = ((LevelledMobs) Bukkit.getPluginManager().getPlugin("LevelledMobs")).levelInterface;
+		levelledMobsManager = new LevelledMobsManager();
+
+		if (levelledMobsManager.hasLevelledMobsInstalled()) {
 			String strLevelledMobsMultiplier = config.getString("LevelledMobsMultiplier").replace("%", "");
 			levelledMobsMultiplier = Double.parseDouble(strLevelledMobsMultiplier)/100;
 			plugin.getMessageManager().logToConsole("&b[MoneyFromMobs] Found LevelledMobs and successfully loaded multiplier of " + strLevelledMobsMultiplier + "% per level of mob");

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>MoneyFromMobs</groupId>
     <artifactId>MoneyFromMobs</artifactId>
-    <version>4.8</version>
+    <version>4.8.1</version>
     <name>MoneyFromMobs</name>
     <description>Makes mobs drop money with looting multiplier</description>
     <properties>
@@ -88,11 +88,6 @@
             <artifactId>authlib</artifactId>
             <version>1.5.21</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.lokka30</groupId>
-            <artifactId>LevelledMobs</artifactId>
-            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>com.github.MilkBowl</groupId>


### PR DESCRIPTION
Removed LevelledMobs class dependencies so it will work with all versions of LevelledMobs.

On Monday, May 20, 2023 we released LevelledMobs 4.0 which broke compatibility with MoneyForMobs.
With this update we've changed it so instead on relying on LM's API we simply get the level from the mob's PDC so there are no 3rd party dependencies.