### PR TITLE
Hex support fix

### DIFF
--- a/MoneyFromMobs/src/me/chocolf/moneyfrommobs/managers/MessageManager.java
+++ b/MoneyFromMobs/src/me/chocolf/moneyfrommobs/managers/MessageManager.java
@@ -122,7 +122,7 @@ public class MessageManager {
 			Matcher match = hexColorPattern.matcher(msg);
 			while (match.find()) {
 				String color = msg.substring(match.start(), match.end());
-				msg = msg.replace(color, ChatColor.valueOf(color) + "");
+				msg = msg.replace(color, ChatColor.of(color) + "");
 				match = hexColorPattern.matcher(msg);
 			}
 		}


### PR DESCRIPTION
Simply replaces ChatColor.valueOf to ChatColor.of which fixes console error unknown enum value in console if user uses hex in messages.